### PR TITLE
allow jenkins to run on arbitrary port

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ Role Variables
 
 ### Default Variables
 
-* `jenkins_web_port1` -- The port Jenkins listens on. (Default `8080`)
+* `jenkins_web_port1` -- The port Jenkins listens on. (Default `8080`). Ports below 1024 will not work out-of-the-box as the jenkins app is not running under root.
 
 * `jenkins_uri` -- URI *WITHOUT* the trailing slash. (Default `http://localhost`)
 

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,6 @@
 ---
 - name: reload jenkins
   uri: method=POST url={{ jenkins_uri }}:{{ jenkins_web_port }}/safeRestart follow_redirects=no status_code=302
+
+- name: restart jenkins
+  service: name=jenkins state=restarted enabled=yes

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -41,6 +41,16 @@
   tags:
     - jenkins
 
+- name: jenkins HTTP port
+  lineinfile:
+    dest: /etc/sysconfig/jenkins
+    regexp: "^JENKINS_PORT"
+    line: "JENKINS_PORT=\"{{ jenkins_web_port }}\""
+  notify:
+    - restart jenkins
+  tags:
+    - jenkins
+
 - name: enable jenkins
   service: name=jenkins enabled=yes
   tags:


### PR DESCRIPTION
basically just update /etc/sysconfig/jenkins with the port number from jenkins_web_port
